### PR TITLE
Add credit to the alphagov styleguide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # M&S Style guides
 
-This is a collection of styleguides for development of apps on M&S.
+This is a collection of styleguides for development of apps on M&S. Adapted from the great [AlphaGov Styleguides][alpha].
 
 ## Languages
 
@@ -35,6 +35,7 @@ This is a collection of styleguides for development of apps on M&S.
 (Leaving this here for now. We don't have an equivalent atm.)
 [govuk-elements][govuk-elements] – layout, typography, colour, images, icons, forms, buttons and data used on GOV.UK.
 
+[alpha]: https://github.com/alphagov/styleguides
 [api]: api.md
 [css]: css.md
 [gem]: rubygems.md


### PR DESCRIPTION
This PR adds a mention to README.md to give credit to the alphagov styleguide repo, of which this repo was originally adapted from.

This is in preparation for @jabley turning this repository from a fork into a full repository, so team members can search the repository (you cannot search forked repos). By removing the 'forked' status, there would no longer be a note saying this was forked from AlphaGov, so I'm adding the credit manually myself.

:sun_with_face: 