### PR TITLE
Fix intellij imports to conform to checkstyle

### DIFF
--- a/java-intellij-config.xml
+++ b/java-intellij-config.xml
@@ -4,6 +4,8 @@
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
+      <package name="" withSubpackages="true" static="true" />
+      <emptyLine />
       <package name="com.mns" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="android" withSubpackages="true" static="false" />
@@ -89,6 +91,8 @@
       <package name="hep" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="ie" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="io" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="imageinfo" withSubpackages="true" static="false" />
       <emptyLine />
@@ -235,8 +239,6 @@
       <package name="javax" withSubpackages="true" static="false" />
       <emptyLine />
       <package name="" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="true" />
     </value>
   </option>
   <option name="RIGHT_MARGIN" value="100" />


### PR DESCRIPTION
`Optimizing imports` in intellij was ordering the imports in a way that did not conform to the checkstyles config.

I have moved the `static` imports to the top and added in `io` imports.